### PR TITLE
build.sh fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,14 +1,16 @@
 #!/bin/sh
 
+set -e
+
 mkdir -p build
 
 echo "building double-conversion dependency"
 cd ryu/third_party/double-conversion
-mkdir -p build
-cd build
+mkdir -p build-ryu
+cd build-ryu
 cmake .. -DCMAKE_BUILD_TYPE=Release > /dev/null
 make -j4 > /dev/null
-cp libdouble-conversion.a ../../../../build
+cp double-conversion/libdouble-conversion.a ../../../../build
 cd ../../../..
 
 echo "building reference benchmark"


### PR DESCRIPTION
# Changes

- Fix path to `libdouble-conversion.a`
- Change the ryu submodule CMake build directory to `build-ryu` to avoid conflict
- Add `set -e` to the build script to abort on first non-zero exit code

# Overview

#3 changed the path to libdouble-conversion, but on both clean setups I used (see below) this
was the incorrect path, causing an error on fresh build. There was no description in the pull request,
so I don't know the reasoning behind the change. It seems odd that CMake would not have consistent
output paths across platforms, so I must assume this was an oversight. (@data-man ?)

Recent Macs apparently use case-insensitive APFS filesystem by default. Ryu has a `BUILD` file,
so `mkdir -p build` outputs:

    mkdir: build: Not a directory

This is followed by a series of other errors, which is why I included a `set -e` command. (I'm open
to ommitting that change for any reason.)

Of course, running `./clean.sh` calls `rm -rf build`, which removes the `BUILD` file on a case-insensitive
filesystem, which in turn causes git status to show a dirty submodule.

To avoid all that, this diff just picks a different build path.

# Environment

Tested on:
- macOS Catalina with APFS filesystem (2017 13" MacBook Pro)
- Linux Mint 19
